### PR TITLE
[Fix] Migrate Provisioners to Terraform 0.12

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/hashicorp/terraform/providers"
+	"github.com/hashicorp/terraform/provisioners"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
 	"github.com/hashicorp/terraform/terraform"
@@ -33,7 +34,7 @@ import (
 type Platform struct {
 	Code         string
 	Providers    map[string]providers.Factory
-	Provisioners map[string]terraform.ProvisionerFactory
+	Provisioners map[string]provisioners.Factory
 	Vars         map[string]interface{}
 	State        *State
 }
@@ -65,18 +66,13 @@ func (p *Platform) AddProvider(name string, provider terraform.ResourceProvider)
 	return p
 }
 
-func providersFactory(rp terraform.ResourceProvider) providers.Factory {
-	p := NewProvider(rp)
-	return providers.FactoryFixed(p)
-}
-
 func (p *Platform) addDefaultProvisioners() {
-	p.Provisioners = map[string]terraform.ProvisionerFactory{}
+	p.Provisioners = map[string]provisioners.Factory{}
 }
 
 // AddProvisioner adds a new provisioner to the provisioner list
-func (p *Platform) AddProvisioner(name string, provisioner terraform.ProvisionerFactory) *Platform {
-	p.Provisioners[name] = provisioner
+func (p *Platform) AddProvisioner(name string, provisioner terraform.ResourceProvisioner) *Platform {
+	p.Provisioners[name] = provisionersFactory(provisioner)
 	return p
 }
 

--- a/provider.go
+++ b/provider.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Terranova Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package terranova
 
 import (
@@ -38,6 +54,11 @@ func NewProvider(provider terraform.ResourceProvider) *Provider {
 	return &Provider{
 		provider: sp,
 	}
+}
+
+func providersFactory(rp terraform.ResourceProvider) providers.Factory {
+	p := NewProvider(rp)
+	return providers.FactoryFixed(p)
 }
 
 // GetSchema implements the GetSchema from providers.Interface. Returns the

--- a/provisioners.go
+++ b/provisioners.go
@@ -1,0 +1,159 @@
+/*
+Copyright The Terranova Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terranova
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/provisioners"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// Provisioner implements the provisioners.Interface wrapping the legacy
+// terraform.ResourceProvisioner but not using gRPC like terraform does
+type Provisioner struct {
+	provisioner *schema.Provisioner
+	mu          sync.Mutex
+	schema      *configschema.Block
+}
+
+// NewProvisioner creates a Terranova Provisioner to wrap the given legacy ResourceProvisioner
+func NewProvisioner(provisioner terraform.ResourceProvisioner) *Provisioner {
+	sp, ok := provisioner.(*schema.Provisioner)
+	if !ok {
+		return nil
+	}
+	return &Provisioner{
+		provisioner: sp,
+	}
+}
+
+func provisionersFactory(rp terraform.ResourceProvisioner) provisioners.Factory {
+	p := NewProvisioner(rp)
+	return provisioners.FactoryFixed(p)
+}
+
+// GetSchema implements GetSchema from provisioners.Interface. It returns the
+// schema for the provisioner configuration.
+func (p *Provisioner) GetSchema() (resp provisioners.GetSchemaResponse) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.schema != nil {
+		return provisioners.GetSchemaResponse{
+			Provisioner: p.schema,
+		}
+	}
+
+	resp.Provisioner = schema.InternalMap(p.provisioner.Schema).CoreConfigSchema()
+
+	if resp.Provisioner == nil {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("missing provisioner schema"))
+		return resp
+	}
+
+	p.schema = resp.Provisioner
+
+	return resp
+}
+
+// ValidateProvisionerConfig implements ValidateProvisionerConfig from
+// provisioners.Interface. It allows the provisioner to validate the
+// configuration values.
+func (p *Provisioner) ValidateProvisionerConfig(req provisioners.ValidateProvisionerConfigRequest) (resp provisioners.ValidateProvisionerConfigResponse) {
+	cfgSchema := schema.InternalMap(p.provisioner.Schema).CoreConfigSchema()
+	config := terraform.NewResourceConfigShimmed(req.Config, cfgSchema)
+
+	warns, errs := p.provisioner.Validate(config)
+	resp.Diagnostics = appendWarnsAndErrsToDiags(warns, errs)
+
+	return resp
+}
+
+// ProvisionResource implements ProvisionResource from provisioners.Interface.
+// It runs the provisioner with provided configuration.
+// ProvisionResource blocks until the execution is complete.
+// If the returned diagnostics contain any errors, the resource will be
+// left in a tainted state.
+func (p *Provisioner) ProvisionResource(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	cfgSchema := schema.InternalMap(p.provisioner.Schema).CoreConfigSchema()
+	resourceConfig := terraform.NewResourceConfigShimmed(req.Config, cfgSchema)
+
+	conn := stringMapFromValue(req.Connection)
+
+	instanceState := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: conn,
+		},
+		Meta: make(map[string]interface{}),
+	}
+
+	if err := p.provisioner.Apply(req.UIOutput, instanceState, resourceConfig); err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(err)
+	}
+
+	return resp
+}
+
+// Stop implements Stop from provisioners.Interface. It is called to interrupt
+// the provisioner.
+//
+// Stop should not block waiting for in-flight actions to complete. It
+// should take any action it wants and return immediately acknowledging it
+// has received the stop request. Terraform will not make any further API
+// calls to the provisioner after Stop is called.
+//
+// The error returned, if non-nil, is assumed to mean that signaling the
+// stop somehow failed and that the user should expect potentially waiting
+// a longer period of time.
+func (p *Provisioner) Stop() error {
+	return p.provisioner.Stop()
+}
+
+// Close implements Close from provisioners.Interface. It shuts down the plugin
+// process if applicable.
+func (p *Provisioner) Close() error {
+	return nil
+}
+
+// stringMapFromValue converts a cty.Value to a map[stirng]string.
+// This will panic if the val is not a cty.Map(cty.String).
+func stringMapFromValue(val cty.Value) map[string]string {
+	m := map[string]string{}
+	if val.IsNull() || !val.IsKnown() {
+		return m
+	}
+
+	for it := val.ElementIterator(); it.Next(); {
+		ak, av := it.Element()
+		name := ak.AsString()
+
+		if !av.IsKnown() || av.IsNull() {
+			continue
+		}
+
+		av, _ = convert.Convert(av, cty.String)
+		m[name] = av.AsString()
+	}
+
+	return m
+}


### PR DESCRIPTION
<!--
Pull requests are always welcome

Not sure if that typo is worth a pull request? Found a bug and know how to fix
it? Do it! We will appreciate it. Any significant improvement should be
documented as [a GitHub issue](https://github.com/johandry/terranova/issues) before
anybody starts working on it.

We are always thrilled to receive pull requests. We do our best to process them
quickly. If your pull request is not accepted on the first try,
don't get discouraged!

** Make sure all your commits include a signature generated with `git commit -s` **
-->

**Community Note**

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Ensure you have added or ran the appropriate tests for this pull request
* If the PR is unfinished, add `[WIP]` prefix to the pull request title and add the `do-not-merge` label.
* Include in the title the category of this pull request. The categories are: `[WIP]`, `[Feature]` or `[Fix]`. If the category is unknown use `[WIP]`, once the PR is ready to be merged replace `[WIP]` for the right category.
* Always assign label(s) to your PR.

**What this PR does / Why we need it:**
Fixes #14 
The migration was incomplete, the Provisioners were not migrated to Terraform 0.12. 
This PR complete the migration of the Provisioners and - as of now - all the Terranova code. 

**How I did it:**
Follow the same method as the Providers. Terraform uses gRPC to have plugins to attache the Provisioners and Providers. Terranova, instead, use them directly. At this time there is no need to use gRPC or plugins because these objects are embedded into the code.

**How to verify it:**
Execute the code from `github.com/johandry/terranova-examples/aws/ec2`

**Description for the changelog:**
- Make Provisioners works with Terraform 0.12
