### PR TITLE
[Feature] Improve Log Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ func main() {
   defer logMiddleware.Close()
 
   platform, err := terranova.NewPlatform(code).
-    AddMiddleware(logMiddleware).
+    SetMiddleware(logMiddleware).
     AddProvider("aws", aws.Provider()).
     Var("c", count).
     Var("key_name", keyName).

--- a/README.md
+++ b/README.md
@@ -168,15 +168,17 @@ logMiddleware := logger.NewMiddleware()
 defer logMiddleware.Close()
 ```
 
-As soon as the first line is execute every line printed by the standard `log` is intercepted by the Log Middleware and printed by the provided logger. This hijack will end when the Log Middleware is closed. To make the platform use the middleware, add it with `AddMiddleware()` to the platform.
+You can decide when the Log Middleware starts intercepting the standard `log` with `logMiddleware.Start()`, if you don't them the Log Middleware will start intercepting every line printed by the standard `log` when Terranova execute an action that makes Terraform to print something to the standard `log`. 
+
+Every line intercepted by the Log Middleware is printed by the provided logger. This hijack will end when the Log Middleware is closed. To make the platform use the middleware, add it with `SetMiddleware()` to the platform.
 
 ```go
-platform.AddMiddleware(logMiddleware)
+platform.SetMiddleware(logMiddleware)
 ```
 
 A logger is an instance of the interface `Logger`. If the Log Middleware is created without parameter the default logger will be used, it prints the INFO, WARN and ERROR log entries of Terraform. To create your own logger check the examples in the [Terranova Examples](https://github.com/johandry/terranova-examples/tree/master/custom-logs) repository.
 
-**IMPORTANT**: It's recommended to create your own instance of  `log` and not use the standard log when the Log Middleware is in use. Everything that is printed using the standard log will be intercepted by the Log Middleware and processed by the Logger. So, use your own custom log or do something like this before creating the Log Middleware:
+**IMPORTANT**: It's recommended to create your own instance of `log` and not use the standard log when the Log Middleware is in use. Everything that is printed using the standard log will be intercepted by the Log Middleware and processed by the Logger. So, use your own custom log or do something like this before creating the Log Middleware:
 
 ```go
 log := log.New(os.Stderr, "", log.LstdFlags)

--- a/logger/middleware.go
+++ b/logger/middleware.go
@@ -60,6 +60,10 @@ func (m *Middleware) IsEnabled() bool {
 func (m *Middleware) Close() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.prevWriter == nil {
+		return
+	}
 	log.SetOutput(m.prevWriter)
 	m.prevWriter = nil
 }

--- a/logger/middleware.go
+++ b/logger/middleware.go
@@ -17,7 +17,7 @@ const TracePrefix = "[TRACE] "
 type Middleware struct {
 	log        Logger
 	prevWriter io.Writer
-	mu         sync.Mutex
+	mu         sync.Mutex // protects the previous Writer, ensure atomic set/unset/checks of prevWriter
 }
 
 // NewMiddleware creates a new instance of Middleware with the Standard
@@ -35,20 +35,33 @@ func NewMiddleware(l ...Logger) *Middleware {
 		log: lgr,
 	}
 
-	// Redirect the Terraform log output to the middleware. Then Write() will send
-	// the right output to the received/created logger
+	return m
+}
+
+// Start make the Middleware starts intercepting the log output and sending the
+// log entries to the defined logger
+func (m *Middleware) Start() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	prevWriter := log.Writer()
 	log.SetOutput(m)
 	m.prevWriter = prevWriter
+}
 
-	return m
+// IsEnabled returns true if the Middleware is intercepting the log output or not
+func (m *Middleware) IsEnabled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.prevWriter != nil
 }
 
 // Close restore the output of the standard logger (used by Terraform) and stop
 // using the Middleware
 func (m *Middleware) Close() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	log.SetOutput(m.prevWriter)
-	m.log = nil
+	m.prevWriter = nil
 }
 
 // SetLogger sets or changes the logger of the Middleware, which is the logger

--- a/logger/middleware_test.go
+++ b/logger/middleware_test.go
@@ -73,6 +73,37 @@ func TestNewMiddleware(t *testing.T) {
 	})
 }
 
+func TestMiddleware_IsEnabled(t *testing.T) {
+	l := NewLog(ioutil.Discard, "DISCARD", LogLevelTrace)
+	lm := NewMiddleware(l)
+	defer lm.Close()
+
+	tests := []struct {
+		name   string
+		action string
+		want   bool
+	}{
+		{"is enable before start?", "", false},
+		{"is enable after start?", "start", true},
+		{"is enable after close?", "close", false},
+		{"is enable after start when was closed?", "start", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			switch tt.action {
+			case "start":
+				lm.Start()
+			case "close":
+				lm.Close()
+			}
+
+			if enabled := lm.IsEnabled(); enabled != tt.want {
+				t.Errorf("IsEnabled() = %v, want pattern %v", enabled, tt.want)
+			}
+		})
+	}
+}
+
 const (
 	Rdate       = `[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9]`
 	Rtime       = `[0-9][0-9]:[0-9][0-9]:[0-9][0-9]`

--- a/logger/middleware_test.go
+++ b/logger/middleware_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestNewMiddleware(t *testing.T) {
 	tnLogger := NewLog(os.Stdout, "", DefLogLevel)
-	stdLogWriter := log.Writer()
 	discardLogger := NewLog(ioutil.Discard, "DISCARD", LogLevelTrace)
 
 	tests := []struct {
@@ -23,16 +22,13 @@ func TestNewMiddleware(t *testing.T) {
 		want *Middleware
 	}{
 		{"no logger", nil, &Middleware{
-			log:        tnLogger,
-			prevWriter: stdLogWriter,
+			log: tnLogger,
 		}},
 		{"std logger", tnLogger, &Middleware{
-			log:        tnLogger,
-			prevWriter: stdLogWriter,
+			log: tnLogger,
 		}},
 		{"discard logger", discardLogger, &Middleware{
-			log:        discardLogger,
-			prevWriter: stdLogWriter,
+			log: discardLogger,
 		}},
 	}
 	for _, tt := range tests {
@@ -50,8 +46,7 @@ func TestNewMiddleware(t *testing.T) {
 		got := NewMiddleware()
 		defer got.Close()
 		want := &Middleware{
-			log:        tnLogger,
-			prevWriter: stdLogWriter,
+			log: tnLogger,
 		}
 
 		if !reflect.DeepEqual(got, want) {
@@ -63,8 +58,7 @@ func TestNewMiddleware(t *testing.T) {
 		got := NewMiddleware(discardLogger, tnLogger, nil)
 		defer got.Close()
 		want := &Middleware{
-			log:        discardLogger,
-			prevWriter: stdLogWriter,
+			log: discardLogger,
 		}
 
 		if !reflect.DeepEqual(got, want) {
@@ -73,10 +67,82 @@ func TestNewMiddleware(t *testing.T) {
 	})
 }
 
+func TestMiddleware_IgnoreOwnLog(t *testing.T) {
+	tfBuf := new(bytes.Buffer)
+	logBuf := new(bytes.Buffer)
+
+	check := func(owner, got, pattern string) {
+		line := got
+		if len(got) > 0 {
+			line = got[0 : len(got)-1]
+		}
+
+		matched, err := regexp.MatchString(pattern, line)
+		if err != nil {
+			t.Fatal(owner+" pattern did not compile:", err)
+		}
+		if !matched {
+			t.Errorf(owner+" Print = %v, want pattern %v", line, pattern)
+		}
+	}
+	checkOutput := func(tfPattern, logPattern string) {
+		check("Middleware/Terraform", tfBuf.String(), tfPattern)
+		check("Log", logBuf.String(), logPattern)
+	}
+
+	tests := []struct {
+		name       string
+		tfPattern  string
+		logPattern string
+		f          func(lm *Middleware)
+	}{
+		{"TF captured, no log",
+			"^DEBUG \\[ " + Rdate + " " + Rtime + " \\] this line is captured by the Log Middleware$",
+			"",
+			func(lm *Middleware) {
+				lm.Start()
+
+				mockTerraformLog("debug", "this line is captured by the Log Middleware")
+			},
+		},
+		{"start, def log: no TF captured, log printed",
+			"",
+			"^" + Rdate + " " + Rtime + " \\[DEBUG\\] this line is not captured by the Log Middleware$",
+			func(lm *Middleware) {
+				lm.Start()
+				log := log.New(logBuf, "", log.LstdFlags)
+
+				log.Printf("[DEBUG] this line is not captured by the Log Middleware")
+			},
+		},
+		{"def log, start: no TF captured, log printed",
+			"",
+			"^" + Rdate + " " + Rtime + " \\[DEBUG\\] this line is not captured by the Log Middleware$",
+			func(lm *Middleware) {
+				log := log.New(logBuf, "", log.LstdFlags)
+				lm.Start()
+
+				log.Printf("[DEBUG] this line is not captured by the Log Middleware")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLog := NewMockLog(tfBuf)
+			lm := NewMiddleware(mockLog)
+			defer lm.Close()
+			defer tfBuf.Reset()
+			defer logBuf.Reset()
+
+			tt.f(lm)
+			checkOutput(tt.tfPattern, tt.logPattern)
+		})
+	}
+}
+
 func TestMiddleware_IsEnabled(t *testing.T) {
 	l := NewLog(ioutil.Discard, "DISCARD", LogLevelTrace)
-	lm := NewMiddleware(l)
-	defer lm.Close()
 
 	tests := []struct {
 		name   string
@@ -84,17 +150,23 @@ func TestMiddleware_IsEnabled(t *testing.T) {
 		want   bool
 	}{
 		{"is enable before start?", "", false},
+		{"is enable after close when not started?", "close", false},
 		{"is enable after start?", "start", true},
-		{"is enable after close?", "close", false},
-		{"is enable after start when was closed?", "start", true},
+		{"is enable after close?", "start,close", false},
+		{"is enable after start when was closed?", "start,close,start", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			switch tt.action {
-			case "start":
-				lm.Start()
-			case "close":
-				lm.Close()
+			lm := NewMiddleware(l)
+			defer lm.Close()
+
+			for _, a := range strings.Split(tt.action, ",") {
+				switch a {
+				case "start":
+					lm.Start()
+				case "close":
+					lm.Close()
+				}
 			}
 
 			if enabled := lm.IsEnabled(); enabled != tt.want {
@@ -143,6 +215,8 @@ func TestMiddlewarePrint(t *testing.T) {
 			mockLog := NewMockLog(buf)
 			lm := NewMiddleware(mockLog)
 			defer lm.Close()
+
+			lm.Start()
 
 			mockTerraformLog(tt.tfLogEntryType, tt.tfLogEntry)
 			got := buf.String()

--- a/platform.go
+++ b/platform.go
@@ -136,8 +136,8 @@ func (p *Platform) ReadStateFromFile(filename string) (*Platform, error) {
 	return p.ReadState(file)
 }
 
-// AddMiddleware adds the given log middleware into the Platform
-func (p *Platform) AddMiddleware(lm *logger.Middleware) *Platform {
+// SetMiddleware assigns the given log middleware into the Platform
+func (p *Platform) SetMiddleware(lm *logger.Middleware) *Platform {
 	p.LogMiddleware = lm
 	return p
 }

--- a/terranova.go
+++ b/terranova.go
@@ -36,6 +36,8 @@ import (
 // Apply brings the platform to the desired state. It'll destroy the platform
 // when `destroy` is `true`.
 func (p *Platform) Apply(destroy bool) error {
+	p.startMiddleware()
+
 	countHook := new(local.CountHook)
 	stateHook := new(local.StateHook)
 
@@ -72,6 +74,8 @@ func (p *Platform) Apply(destroy bool) error {
 // Plan returns execution plan for an existing configuration to apply to the
 // platform.
 func (p *Platform) Plan(destroy bool) (*plans.Plan, error) {
+	p.startMiddleware()
+
 	ctx, err := p.newContext(destroy)
 	if err != nil {
 		return nil, err
@@ -87,6 +91,17 @@ func (p *Platform) Plan(destroy bool) (*plans.Plan, error) {
 	}
 
 	return plan, nil
+}
+
+// startMiddleware starts the Log Middleware to intercept the logs if it has not
+// been already started
+func (p *Platform) startMiddleware() {
+	if p.LogMiddleware == nil {
+		return
+	}
+	if !p.LogMiddleware.IsEnabled() {
+		p.LogMiddleware.Start()
+	}
 }
 
 // newContext creates the Terraform context or configuration


### PR DESCRIPTION
<!--
Pull requests are always welcome

Not sure if that typo is worth a pull request? Found a bug and know how to fix
it? Do it! We will appreciate it. Any significant improvement should be
documented as [a GitHub issue](https://github.com/johandry/terranova/issues) before
anybody starts working on it.

We are always thrilled to receive pull requests. We do our best to process them
quickly. If your pull request is not accepted on the first try,
don't get discouraged!

** Make sure all your commits include a signature generated with `git commit -s` **
-->

**Community Note**

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Ensure you have added or ran the appropriate tests for this pull request
* If the PR is unfinished, add `[WIP]` prefix to the pull request title and add the `do-not-merge` label.
* Include in the title the category of this pull request. The categories are: `[WIP]`, `[Feature]` or `[Fix]`. If the category is unknown use `[WIP]`, once the PR is ready to be merged replace `[WIP]` for the right category.
* Always assign label(s) to your PR.

**What this PR does / Why we need it:**
Implement improvement/issue #21 

**References:**
 - Closes #21 

**How I did it:**
Add function `Start()` to the Log Middleware to allow the developer when the Log Middleware starts to intercept the Terraform logs.
Add the function `IsEnabled()` to the Log Middleware to let know the developer and to Terranova when the Log Middleware is intercepting logs.
The functions `Apply()` and `Plan()` start the Log Middleware if exists and if it's not enabled.

**How to verify it:**
A few Unit Test were added.

**IMPORTAT:**
For future PR's when there is a function that execute an action in Terraform that cause logs, this function should call `p.startMiddleware()`

**Description for the changelog:**
- Allow the developer to control when the Log Middleware start intercepting logs from Terraform
