### PR TITLE
[Feature] Add Stats

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/backend/local"
 	"github.com/hashicorp/terraform/providers"
 	"github.com/hashicorp/terraform/provisioners"
 	"github.com/hashicorp/terraform/states"
@@ -39,6 +40,8 @@ type Platform struct {
 	Hooks         []terraform.Hook
 	LogMiddleware *logger.Middleware
 	stateMgr      statemgr.Writer
+	countHook     *local.CountHook
+	ExpectedStats *Stats
 	mu            sync.Mutex
 }
 

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,71 @@
+package terranova
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/backend/local"
+	"github.com/hashicorp/terraform/plans"
+)
+
+// Stats encapsulate the statistics of changes to apply or applied
+type Stats struct {
+	Add, Change, Destroy int
+	fromPlan             bool
+}
+
+// NewStats creates an empty stats
+func NewStats() *Stats {
+	return &Stats{}
+}
+
+// FromPlan return stats from a given plan
+func (s *Stats) FromPlan(plan *plans.Plan) *Stats {
+	if plan == nil || plan.Changes == nil || plan.Changes.Empty() {
+		return s
+	}
+
+	s.Add, s.Change, s.Destroy = 0, 0, 0
+	s.fromPlan = true
+
+	for _, r := range plan.Changes.Resources {
+		switch r.Action {
+		case plans.Create:
+			s.Add++
+		case plans.Update:
+			s.Change++
+		case plans.DeleteThenCreate, plans.CreateThenDelete:
+			s.Add++
+			s.Destroy++
+		case plans.Delete:
+			if r.Addr.Resource.Resource.Mode != addrs.DataResourceMode {
+				s.Destroy++
+			}
+		}
+	}
+
+	return s
+}
+
+// FromCountHook return stats from a given count hook
+func (s *Stats) FromCountHook(countHook *local.CountHook) *Stats {
+	if countHook == nil {
+		return s
+	}
+
+	s.Add, s.Change, s.Destroy = countHook.Added, countHook.Changed, countHook.Removed
+
+	return s
+}
+
+func (s *Stats) String() string {
+	if s.fromPlan {
+		return fmt.Sprintf("resources: %d to add, %d to change, %d to destroy", s.Add, s.Change, s.Destroy)
+	}
+	return fmt.Sprintf("resources: %d added, %d changed, %d destroyed", s.Add, s.Change, s.Destroy)
+}
+
+// Stats return the current status from the count hook
+func (p *Platform) Stats() *Stats {
+	return NewStats().FromCountHook(p.countHook)
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,149 @@
+package terranova
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform/backend/local"
+)
+
+func TestStats_FromPlan(t *testing.T) {
+	type statsFields struct {
+		Add      int
+		Change   int
+		Destroy  int
+		fromPlan bool
+	}
+	tests := []struct {
+		name           string
+		platformFields platformFields
+		destroy        bool
+		fields         statsFields
+		want           *Stats
+		wantStr        string
+	}{
+		{"null data source", testsPlatformsFields["null data source"], false, statsFields{-1, -1, -1, false}, &Stats{0, 0, 0, true}, "resources: 0 to add, 0 to change, 0 to destroy"},
+		{"test instance", testsPlatformsFields["test instance"], false, statsFields{-1, -1, -1, false}, &Stats{1, 0, 0, true}, "resources: 1 to add, 0 to change, 0 to destroy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Stats{
+				Add:      tt.fields.Add,
+				Change:   tt.fields.Change,
+				Destroy:  tt.fields.Destroy,
+				fromPlan: tt.fields.fromPlan,
+			}
+
+			p := newPlatformForTest(tt.platformFields)
+
+			plan, err := p.Plan(tt.destroy)
+			if err != nil {
+				t.Errorf("Failed to create the platform")
+				return
+			}
+
+			if got := s.FromPlan(plan); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Stats.FromPlan() = %+v, want %+v", got, tt.want)
+			}
+
+			if gotStr := s.String(); gotStr != tt.wantStr {
+				t.Errorf("Stats.String() = %v, want %v", gotStr, tt.wantStr)
+			}
+
+			// if err := p.Apply(tt.destroy); err != nil {
+			// 	t.Errorf("Failed to apply the platform")
+			// 	return
+			// }
+
+			// if got := p.ExpectedStats; !reflect.DeepEqual(got, tt.want) {
+			// 	t.Errorf("Platform.ExpectedStats = %+v, want %+v", got, tt.want)
+			// }
+
+		})
+	}
+}
+
+func TestPlatform_Stats(t *testing.T) {
+	tests := []struct {
+		name           string
+		platformFields platformFields
+		want           *Stats
+		wantStr        string
+	}{
+		{"null data source", testsPlatformsFields["null data source"], &Stats{0, 0, 0, false}, "resources: 0 added, 0 changed, 0 destroyed"},
+		// {"test instance", testsPlatformsFields["test instance"], &Stats{1, 0, 0, false}, "resources: 1 added, 0 changed, 0 destroyed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newPlatformForTest(tt.platformFields).Stats()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Platform.Stats() = %v, want %v", got, tt.want)
+			}
+
+			if gotStr := got.String(); gotStr != tt.wantStr {
+				t.Errorf("Stats.String() = %v, want %v", gotStr, tt.wantStr)
+			}
+		})
+	}
+}
+
+func TestStats_FromCountHook(t *testing.T) {
+	type statsFields struct {
+		Add      int
+		Change   int
+		Destroy  int
+		fromPlan bool
+	}
+	tests := []struct {
+		name      string
+		fields    statsFields
+		countHook *local.CountHook
+		want      *Stats
+		wantStr   string
+	}{
+		{"simple", statsFields{0, 0, 0, false}, &local.CountHook{
+			Added:          0,
+			Changed:        0,
+			Removed:        0,
+			ToAdd:          0,
+			ToChange:       0,
+			ToRemove:       0,
+			ToRemoveAndAdd: 0,
+		}, &Stats{0, 0, 0, false}, "resources: 0 added, 0 changed, 0 destroyed"},
+		{"added-n-removed", statsFields{0, 0, 0, false}, &local.CountHook{
+			Added:          5,
+			Changed:        0,
+			Removed:        4,
+			ToAdd:          0,
+			ToChange:       0,
+			ToRemove:       0,
+			ToRemoveAndAdd: 0,
+		}, &Stats{5, 0, 4, false}, "resources: 5 added, 0 changed, 4 destroyed"},
+		{"to-add-n-remove", statsFields{0, 0, 0, false}, &local.CountHook{
+			Added:          0,
+			Changed:        0,
+			Removed:        0,
+			ToAdd:          5,
+			ToChange:       0,
+			ToRemove:       4,
+			ToRemoveAndAdd: 0,
+		}, &Stats{0, 0, 0, false}, "resources: 0 added, 0 changed, 0 destroyed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Stats{
+				Add:      tt.fields.Add,
+				Change:   tt.fields.Change,
+				Destroy:  tt.fields.Destroy,
+				fromPlan: tt.fields.fromPlan,
+			}
+			got := s.FromCountHook(tt.countHook)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Stats.FromCountHook() = %v, want %v", got, tt.want)
+			}
+			if gotStr := got.String(); gotStr != tt.wantStr {
+				t.Errorf("Stats.FromCountHook().String() = %v, want %v", gotStr, tt.wantStr)
+			}
+		})
+	}
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -50,14 +50,14 @@ func TestStats_FromPlan(t *testing.T) {
 				t.Errorf("Stats.String() = %v, want %v", gotStr, tt.wantStr)
 			}
 
-			// if err := p.Apply(tt.destroy); err != nil {
-			// 	t.Errorf("Failed to apply the platform")
-			// 	return
-			// }
+			if err := p.Apply(tt.destroy); err != nil {
+				t.Errorf("Failed to apply the platform")
+				return
+			}
 
-			// if got := p.ExpectedStats; !reflect.DeepEqual(got, tt.want) {
-			// 	t.Errorf("Platform.ExpectedStats = %+v, want %+v", got, tt.want)
-			// }
+			if got := p.ExpectedStats; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Platform.ExpectedStats = %+v, want %+v", got, tt.want)
+			}
 
 		})
 	}
@@ -67,15 +67,21 @@ func TestPlatform_Stats(t *testing.T) {
 	tests := []struct {
 		name           string
 		platformFields platformFields
+		destroy        bool
 		want           *Stats
 		wantStr        string
 	}{
-		{"null data source", testsPlatformsFields["null data source"], &Stats{0, 0, 0, false}, "resources: 0 added, 0 changed, 0 destroyed"},
-		// {"test instance", testsPlatformsFields["test instance"], &Stats{1, 0, 0, false}, "resources: 1 added, 0 changed, 0 destroyed"},
+		{"null data source", testsPlatformsFields["null data source"], false, &Stats{0, 0, 0, false}, "resources: 0 added, 0 changed, 0 destroyed"},
+		{"test instance", testsPlatformsFields["test instance"], false, &Stats{1, 0, 0, false}, "resources: 1 added, 0 changed, 0 destroyed"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := newPlatformForTest(tt.platformFields).Stats()
+			p := newPlatformForTest(tt.platformFields)
+			if err := p.Apply(tt.destroy); err != nil {
+				t.Errorf("Failed to apply the changes. Error: %s", err)
+				return
+			}
+			got := p.Stats()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Platform.Stats() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
<!--
Pull requests are always welcome

Not sure if that typo is worth a pull request? Found a bug and know how to fix
it? Do it! We will appreciate it. Any significant improvement should be
documented as [a GitHub issue](https://github.com/johandry/terranova/issues) before
anybody starts working on it.

We are always thrilled to receive pull requests. We do our best to process them
quickly. If your pull request is not accepted on the first try,
don't get discouraged!

** Make sure all your commits include a signature generated with `git commit -s` **
-->

**Community Note**

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Ensure you have added or ran the appropriate tests for this pull request
* If the PR is unfinished, add `[WIP]` prefix to the pull request title and add the `do-not-merge` label.
* Include in the title the category of this pull request. The categories are: `[WIP]`, `[Feature]` or `[Fix]`. If the category is unknown use `[WIP]`, once the PR is ready to be merged replace `[WIP]` for the right category.
* Always assign label(s) to your PR.

**What this PR does / Why we need it:**
This PR adds the Stats to the platform. Stats count the number of resources added, changed and deleted or to add, to change and to delete. 
It allows to the developer to know the expected stats after applying the code, and the current stats at any time.

**References:**
List of issues this PR fixes using the prefix `Fixes`, `Closes` or `Resolves` and the issue number or link. Format Examples: `Fixes #<issue number>`, `Closes <link of issue>` or `Resolves #<issue number>`.
The issues will be closed automatically when this pull request is merged. Example:
 - Closes #9 

**How I did it:**
Define the `Stats` struct to encapsulate the number of adds, changes and deletes. `Platform.Apply()` uses the method `Stats.FromPlan()` to create the stats from the initial plan and store them in `Platform.ExpectedStats`. The method `Platform.Stats()` provide the current stats obtained from the `CountHook` in the platform.

**How to verify it:**
Execute the unit tests from `stats_test.go`.
Use Terranova with a slow Terraform code, execute a Go routine to print the expected state and current state while `Apply()` is being executed.

**Description for the changelog:**
- Add Stats to the platform to know the expected stats and current stats while the changes are applied.
